### PR TITLE
🧪 Add tests for OpenGraph and Twitter meta tags

### DIFF
--- a/tests/seo.spec.ts
+++ b/tests/seo.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+
+test('has opengraph and twitter meta tags', async ({ page }) => {
+  await page.goto('/');
+
+  // Verify OpenGraph tags
+  await Promise.all([
+    expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+      'content',
+      'Rahul Jain'
+    ),
+    expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
+      'content',
+      'https://rahulja.in/assets/images/rahul-jain.jpg'
+    ),
+    expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
+      'content',
+      'https://rahulja.in'
+    ),
+    expect(page.locator('meta[property="og:description"]')).toHaveAttribute(
+      'content',
+      'Rahul Jain is a senior software engineer and tech enthusiast living in Singapore'
+    ),
+    expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute(
+      'content',
+      'Rahul Jain'
+    ),
+    expect(page.locator('meta[property="og:type"]')).toHaveAttribute(
+      'content',
+      'website'
+    ),
+  ]);
+
+  // Verify Twitter tags
+  await Promise.all([
+    expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute(
+      'content',
+      'summary'
+    ),
+    expect(page.locator('meta[name="twitter:url"]')).toHaveAttribute(
+      'content',
+      'https://rahulja.in'
+    ),
+    expect(page.locator('meta[name="twitter:creator"]')).toHaveAttribute(
+      'content',
+      '@xRahulJain'
+    ),
+    expect(page.locator('meta[name="twitter:title"]')).toHaveAttribute(
+      'content',
+      'Rahul Jain'
+    ),
+    expect(page.locator('meta[name="twitter:description"]')).toHaveAttribute(
+      'content',
+      'Rahul Jain is a senior software engineer and tech enthusiast living in Singapore'
+    ),
+    expect(page.locator('meta[name="twitter:image"]')).toHaveAttribute(
+      'content',
+      'https://rahulja.in/assets/images/rahul-jain.jpg'
+    ),
+  ]);
+});


### PR DESCRIPTION
🎯 **What:** Missing test validation for OpenGraph (`og:*`) and Twitter (`twitter:*`) meta tags in `index.html`.

📊 **Coverage:** Added explicit Playwright assertions for `og:title`, `og:image`, `og:url`, `og:description`, `og:site_name`, `og:type` and their Twitter equivalents. Tests verify that these tags exist and have the correct `content` attributes.

✨ **Result:** Improved test coverage and reliability. The full suite of SEO meta tags is now automatically verified on every test run, preventing accidental removal or modification of these important tags.

---
*PR created automatically by Jules for task [16736624742000448619](https://jules.google.com/task/16736624742000448619) started by @xRahul*