### PR TITLE
🧪 [testing improvement] Add Playwright validation for JSON-LD structured data

### DIFF
--- a/tests/structured-data.spec.ts
+++ b/tests/structured-data.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+test('has valid structured data', async ({ page }) => {
+  await page.goto('/');
+
+  const scriptTag = page.locator('script[type="application/ld+json"]');
+  await expect(scriptTag).toBeAttached();
+
+  const scriptContent = await scriptTag.textContent();
+  expect(scriptContent).not.toBeNull();
+
+  const data = JSON.parse(scriptContent as string);
+
+  expect(data['@context']).toBe('http://schema.org');
+  expect(data['@type']).toBe('Person');
+  expect(data.name).toBe('Rahul Jain');
+  expect(data.jobTitle).toBe('Senior Software Engineer');
+  expect(data.url).toBe('https://rahulja.in');
+
+  const expectedSameAs = [
+    'https://www.linkedin.com/in/xrahuljain',
+    'https://github.com/xRahul',
+    'https://www.facebook.com/xRahulJain',
+    'https://twitter.com/xRahulJain',
+    'http://stackoverflow.com/users/1435626/rahul',
+  ];
+
+  expect(Array.isArray(data.sameAs)).toBe(true);
+
+  for (const url of expectedSameAs) {
+    expect(data.sameAs).toContain(url);
+  }
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR introduces tests to parse and validate the JSON-LD structured data block embedded in `<script type="application/ld+json">` within `index.html`.

📊 **Coverage:** What scenarios are now tested
The new `tests/structured-data.spec.ts` ensures:
- The JSON-LD script is successfully rendered and has a standard JSON format.
- Context (`http://schema.org`) and entity type (`Person`) are correct.
- Critical entity fields like `name`, `jobTitle`, and `url` match expected values.
- The `sameAs` array includes correct social profiles and URLs.

✨ **Result:** The improvement in test coverage
We now have automated, deterministic coverage for our JSON-LD markup, preventing regressions that could negatively impact the website's SEO indexability and rich snippet presentation in search engines.

---
*PR created automatically by Jules for task [16480379471755490990](https://jules.google.com/task/16480379471755490990) started by @xRahul*