### PR TITLE
🧹 Remove unused CSS class .display-none

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -82,10 +82,6 @@ body,
   will-change: transform;
 }
 
-.display-none {
-  display: none;
-}
-
 @keyframes flip {
   0% {
     transform: rotateY(360deg);

--- a/tests/animation-verification.spec.ts
+++ b/tests/animation-verification.spec.ts
@@ -8,8 +8,7 @@ test('animation container and items exist', async ({ page }) => {
   await expect(container).toBeVisible();
 
   // Initially, before changes, checking for "Software Engineer" text
-  // The current implementation uses ::before, so the text might be in the display-none span
-  // or just invisible.
+  // The current implementation uses ::before, so the text might be invisible.
   // We just want to ensure the page loads and the container is there.
 
   // After changes, we expect 5 spans.


### PR DESCRIPTION
🎯 **What:** Removed the unused `.display-none` CSS class from `src/style.css` and updated a stale comment in `tests/animation-verification.spec.ts` that referenced it.

💡 **Why:** The `.display-none` class was dead code and not used anywhere in the `index.html` file or dynamically via scripts. Removing dead code reduces file size, avoids confusion for future developers, and improves overall code maintainability.

✅ **Verification:** Verified by grepping for "display-none" across the codebase to ensure no remaining references existed. Ran the Playwright test suite (`npx playwright test`) successfully across all browsers and ensured code formatting standards were upheld using `npm run lint`.

✨ **Result:** A cleaner CSS file with no dead code, and an updated test comment that accurately reflects the code's current state.

---
*PR created automatically by Jules for task [4193491388476883761](https://jules.google.com/task/4193491388476883761) started by @xRahul*