### PR TITLE
🧹 [Remove left-over console.log in benchmark tests]

### DIFF
--- a/tests/benchmark.spec.ts
+++ b/tests/benchmark.spec.ts
@@ -31,6 +31,4 @@ test('measure fps of flip animation', async ({ page }) => {
       });
     });
   });
-
-  console.log(`Average FPS: ${fps.toFixed(2)}`);
 });


### PR DESCRIPTION
🎯 **What:** Removed a left-over `console.log` statement from `tests/benchmark.spec.ts` that was logging the average FPS.

💡 **Why:** `console.log` statements left in test code are usually meant for debugging. Removing them keeps the test output clean and improves the maintainability and readability of the codebase.

✅ **Verification:** Verified that the specific line was removed. Ran `npm run format` and `npm run lint` which successfully passed. Also, executed `npx playwright test` to ensure all tests passed and confirmed that no functionality was broken.

✨ **Result:** A cleaner test output and slightly improved code health without altering the behavior of the tests.

---
*PR created automatically by Jules for task [15363707133579170474](https://jules.google.com/task/15363707133579170474) started by @xRahul*