### PR TITLE
🧹 Refactor repeated page navigations in e2e tests

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -1,22 +1,20 @@
 import { test, expect } from '@playwright/test';
 
-test('has title', async ({ page }) => {
+test.beforeEach(async ({ page }) => {
   await page.goto('/');
+});
 
+test('has title', async ({ page }) => {
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle(/Rahul Jain/);
 });
 
 test('has main heading', async ({ page }) => {
-  await page.goto('/');
-
   // Expect the main heading to be visible
   await expect(page.locator('h1.title')).toBeVisible();
 });
 
 test('has social links', async ({ page }) => {
-  await page.goto('/');
-
   // Check for social links
   await Promise.all([
     expect(page.getByLabel('Stack Overflow')).toBeVisible(),


### PR DESCRIPTION
🎯 **What:** Extracted the repeated `await page.goto('/')` setup statements from individual tests in `tests/e2e.spec.ts` into a single `test.beforeEach` block at the top of the file.

💡 **Why:** This reduces code duplication and makes the tests cleaner and easier to read. By centralizing the setup logic, any future changes to the initial page load only need to be updated in one place, improving overall maintainability.

✅ **Verification:** 
- Ran `npm run lint` and `npm run format` to ensure code style compliance.
- Executed `npx playwright test tests/e2e.spec.ts` locally; all tests passed successfully across chromium, firefox, and webkit browsers, confirming no functionality was broken.

✨ **Result:** A more maintainable, concise, and standard test structure within `tests/e2e.spec.ts` without altering test behavior.

---
*PR created automatically by Jules for task [6401734580593120936](https://jules.google.com/task/6401734580593120936) started by @xRahul*