### PR TITLE
🧪 [testing improvement] Add validation for favicon and manifest tags

### DIFF
--- a/tests/seo.spec.ts
+++ b/tests/seo.spec.ts
@@ -59,3 +59,46 @@ test('has opengraph and twitter meta tags', async ({ page }) => {
     ),
   ]);
 });
+
+test('has favicon and manifest tags', async ({ page }) => {
+  await page.goto('/');
+
+  await Promise.all([
+    expect(page.locator('link[rel="manifest"]')).toHaveAttribute(
+      'href',
+      '/manifest.json'
+    ),
+    expect(page.locator('link[rel="apple-touch-icon"]')).toHaveAttribute(
+      'href',
+      '/assets/favicons/apple-touch-icon.png'
+    ),
+    expect(page.locator('link[rel="icon"][sizes="16x16"]')).toHaveAttribute(
+      'href',
+      '/assets/favicons/favicon-16x16.png'
+    ),
+    expect(page.locator('link[rel="icon"][sizes="32x32"]')).toHaveAttribute(
+      'href',
+      '/assets/favicons/favicon-32x32.png'
+    ),
+    expect(page.locator('link[rel="icon"][sizes="96x96"]')).toHaveAttribute(
+      'href',
+      '/assets/favicons/favicon-96x96.png'
+    ),
+    expect(page.locator('link[rel="icon"][sizes="128x128"]')).toHaveAttribute(
+      'href',
+      '/assets/favicons/favicon-128.png'
+    ),
+    expect(page.locator('link[rel="icon"][sizes="192x192"]')).toHaveAttribute(
+      'href',
+      '/assets/favicons/android-chrome-192x192.png'
+    ),
+    expect(page.locator('link[rel="mask-icon"]')).toHaveAttribute(
+      'href',
+      '/assets/favicons/safari-pinned-tab.svg'
+    ),
+    expect(page.locator('link[rel="shortcut icon"]')).toHaveAttribute(
+      'href',
+      '/assets/favicons/favicon.ico'
+    ),
+  ]);
+});


### PR DESCRIPTION
🎯 **What:** The testing gap regarding the missing validation for favicon and manifest `<link>` tags in `index.html` has been addressed.
📊 **Coverage:** Playwright tests now verify the expected `href` paths for the `manifest`, `apple-touch-icon`, `icon` tags (16x16, 32x32, 96x96, 128x128, 192x192), `mask-icon`, and `shortcut icon` in `index.html` ensuring correct references to the `/assets/favicons/` path and `/manifest.json`.
✨ **Result:** Test coverage significantly improves the website's SEO regression testing confidence, preventing issues related to missing or broken PWA/favicon asset references.

---
*PR created automatically by Jules for task [17244484197609301162](https://jules.google.com/task/17244484197609301162) started by @xRahul*