### PR TITLE
🔒 [security] Fix insecure HTTP links to CEC Mohali

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,9 +90,9 @@
           "name": "Chandigarh Engineering College",
           "sameAs": [
             "https://en.wikipedia.org/wiki/Chandigarh_Engineering_College",
-            "http://cecmohali.org"
+            "https://cecmohali.org"
           ],
-          "logo": "http://cecmohali.org/wp-content/themes/cec-mohali/img/logo.jpg",
+          "logo": "https://cecmohali.org/wp-content/themes/cec-mohali/img/logo.jpg",
           "email": "contact@cecmohali.org",
           "address": {
             "@type": "PostalAddress",


### PR DESCRIPTION
🎯 **What:** Updated the structured data (JSON-LD) in `index.html` to use `https://` instead of `http://` for the Chandigarh Engineering College (`cecmohali.org`) URLs in both the `sameAs` array and `logo` field.

⚠️ **Risk:** Using insecure HTTP links for external resources and profile data can expose users to potential man-in-the-middle (MITM) attacks if clicked or fetched, allowing attackers to intercept or manipulate the unencrypted traffic. It can also lead to mixed-content warnings depending on how the data is utilized.

🛡️ **Solution:** The string `http://cecmohali.org` was globally replaced with `https://cecmohali.org` within the `index.html` file to enforce encrypted HTTPS connections.

---
*PR created automatically by Jules for task [2573009459814261556](https://jules.google.com/task/2573009459814261556) started by @xRahul*